### PR TITLE
Basic認証の設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
+
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"] 
+    end
+  end
 end


### PR DESCRIPTION
#What
Basic認証の設定

#Why
アプリケーションにBasic認証を導入するため

#備考
本来，ブランチを作成する必要はなかったかもしれないが練習のため。